### PR TITLE
Flash all data within program memory range

### DIFF
--- a/src/mcbootflash/__init__.py
+++ b/src/mcbootflash/__init__.py
@@ -5,4 +5,4 @@ from .flashing import flash, get_parser
 
 __all__ = ["Bootloader", "BootloaderError", "flash", "get_parser"]
 
-__version__ = "5.1.1"
+__version__ = "5.1.2b1"


### PR DESCRIPTION
Previous behavior ignored any data which is part of a contiguous block of data if any part of the block is outside program memory range. That's probably wrong.