### PR TITLE
Bump version to 7.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [7.0.7] - Development
+
 ## [7.0.6] - 2023-11-01
 
 ### Changed
@@ -188,6 +190,7 @@ _Maintanence release._
 
 _Initial release._
 
+[7.0.7]: https://github.com/bessman/mcbootflash/releases/tag/v7.0.7
 [7.0.6]: https://github.com/bessman/mcbootflash/releases/tag/v7.0.6
 [7.0.5]: https://github.com/bessman/mcbootflash/releases/tag/v7.0.5
 [7.0.4]: https://github.com/bessman/mcbootflash/releases/tag/v7.0.4

--- a/src/mcbootflash/__init__.py
+++ b/src/mcbootflash/__init__.py
@@ -5,4 +5,4 @@ from .flashing import flash, get_parser
 
 __all__ = ["Bootloader", "BootloaderError", "flash", "get_parser"]
 
-__version__ = "7.0.6"
+__version__ = "7.0.7"


### PR DESCRIPTION
From now on, version will be bumped immediately following each release. This makes it simpler to tell whether a user is using the latest release or the head of the development branch.